### PR TITLE
Disconnect DebugClient onExit of debug run

### DIFF
--- a/src/main/java/org/mule/debugger/session/MuleDebuggerSession.java
+++ b/src/main/java/org/mule/debugger/session/MuleDebuggerSession.java
@@ -201,6 +201,7 @@ public class MuleDebuggerSession extends DefaultDebuggerResponseCallback {
     @Override
     public void onExit() {
         isConnected = false;
+        getDebuggerClient().disconnect();
     }
 
     public void eval(String script, final ScriptEvaluationCallback callback) {


### PR DESCRIPTION
I believe Intellij may be triggering `onExit()` when the runtime is stopped.

Before calling `disconnect()` on exit, intellij's cpu would spike with deadlocks from the client (likely stuck in a waiting state).
![image](https://cloud.githubusercontent.com/assets/6200057/13515589/935c87a8-e167-11e5-9f58-3dd0a5f31007.png)
> The steady green cpu usage toward the right is after the runtime was stopped

Now that `disconnect()` is called on exit, cpu drops to nothing and the DebugClient is no longer occupying cpu time
![image](https://cloud.githubusercontent.com/assets/6200057/13515601/b4e07312-e167-11e5-8d05-9ecd5caf6bb1.png)

Issue #12 