### PR TITLE
Add spring import elements and description attribute to MUnit template

### DIFF
--- a/src/main/resources/fileTemplates/internal/MUnit Config.xml.ft
+++ b/src/main/resources/fileTemplates/internal/MUnit Config.xml.ft
@@ -13,8 +13,12 @@
     
     <munit:config name="${NAME}-munit-config"/>
     <mock:config name="${NAME}-mock-config"/>
+
+    <spring:beans>
+      <spring:import resource="${NAME}.xml"/>
+    </spring:beans>
       
-    <munit:test name="${NAME}Test">
+    <munit:test name="${NAME}Test" description="">
       <logger/>
     </munit:test>
     


### PR DESCRIPTION
Add spring import elements out of convenience since this is required to
bootstrap most MUnit tests.

Add description attribute to pre-generated munit:test since it is a
required attribute.